### PR TITLE
Fix output dir for release workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,8 @@
 name: Generate Resume on PR
 on:
   pull_request:
+    paths:
+      - "resume.md"
   workflow_dispatch:
 jobs:
   generate-resume:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           input_path: resume.md
           output_dir: out 
       - name: Rename file
-        run: mv resume/resume.pdf resume/mikeodriscoll_resume.pdf
+        run: mv out/resume.pdf out/mikeodriscoll_resume.pdf
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v0.1.15
         with:


### PR DESCRIPTION
Dir is `out` not `resume`
Also only trigger generation on CV updates.